### PR TITLE
Generalizes the true_percentage_change variable

### DIFF
--- a/notebooks/delta method.ipynb
+++ b/notebooks/delta method.ipynb
@@ -101,7 +101,7 @@
     "    for i in range(bootstrap_iterations):\n",
     "        X = np.random.normal(loc=loc1, scale=scale, size=size)\n",
     "        Y = np.random.normal(loc=loc2, scale=scale, size=size)\n",
-    "        true_percentage_change = loc2 - loc1\n",
+    "        true_percentage_change = loc2 / loc1 - 1\n",
     "        confidence_interval = confidence_interval_delta(X, Y)\n",
     "        if interval_contains_true_p(confidence_interval, true_percentage_change):\n",
     "            coverage += 1\n",


### PR DESCRIPTION
`true_percentage_change` is parametrized such that the results of the `get_coverage` functions are not valid for when loc2 is different from 1. The change aims to generalize that result.